### PR TITLE
fix malformed URL bug

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject loudmoauth "0.1.3-with-url-fix-2"
+(defproject loudmoauth "0.1.4"
   :description "A single user multi provider oauth2 client library."
   :url "http://github.com/njerig/loudmoauth"
   :license {:name "The MIT License (MIT)"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject loudmoauth "0.1.4"
+(defproject loudmoauth "0.1.3-with-url-fix-2"
   :description "A single user multi provider oauth2 client library."
   :url "http://github.com/njerig/loudmoauth"
   :license {:name "The MIT License (MIT)"

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject loudmoauth "0.1.3"
+(defproject loudmoauth "0.1.3-with-url-fix"
   :description "A single user multi provider oauth2 client library."
-  :url "http://github.com/blmstrm/loudmoauth"
+  :url "http://github.com/njerig/loudmoauth"
   :license {:name "The MIT License (MIT)"
             :url "http://opensource.org/licenses/MIT"}
   :plugins [[lein-cloverage "1.0.6"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject loudmoauth "0.1.3-with-url-fix"
+(defproject loudmoauth "0.1.3-with-url-fix-2"
   :description "A single user multi provider oauth2 client library."
   :url "http://github.com/njerig/loudmoauth"
   :license {:name "The MIT License (MIT)"

--- a/src/loudmoauth/core.clj
+++ b/src/loudmoauth/core.clj
@@ -6,6 +6,7 @@
 (defn parse-params
   "Parse parameters from http-response and put on channel."
   [response]
+    (clojure.pprint/pprint response)
     (->>
       response 
       :params

--- a/src/loudmoauth/provider.clj
+++ b/src/loudmoauth/provider.clj
@@ -40,7 +40,7 @@
   (replace (->> (:custom-query-params provider-data) 
                 (merge (select-keys provider-data query-params))
                 (util/change-keys)
-                (client/generate-query-string)) "+" "&"))
+                (client/generate-query-string)) "+" "%20"))
 
 (defn auth-url
   "Build the authorization url."

--- a/src/loudmoauth/provider.clj
+++ b/src/loudmoauth/provider.clj
@@ -40,7 +40,7 @@
   (replace (->> (:custom-query-params provider-data) 
                 (merge (select-keys provider-data query-params))
                 (util/change-keys)
-                (client/generate-query-string)) "+" "%20"))
+                (client/generate-query-string)) "+" "&"))
 
 (defn auth-url
   "Build the authorization url."

--- a/src/loudmoauth/provider.clj
+++ b/src/loudmoauth/provider.clj
@@ -2,7 +2,9 @@
   (:require [clojure.string :as str]
             [clj-http.client :as client] 
             [schema.core :as s]
-            [loudmoauth.util :as util]))
+            [loudmoauth.util :as util]
+            [clojure.string :refer [replace]])
+  (:refer-clojure :exclude [replace]))
 
 (def internal-provider-data
   {:code s/Any
@@ -35,10 +37,10 @@
 (defn query-param-string 
   "Get query-param string from query parameter map."
   [provider-data]
-  (->>
-    (:custom-query-params provider-data) (merge (select-keys provider-data query-params))
-    (util/change-keys)
-    (client/generate-query-string)))
+  (replace (->> (:custom-query-params provider-data) 
+                (merge (select-keys provider-data query-params))
+                (util/change-keys)
+                (client/generate-query-string)) "+" "%20"))
 
 (defn auth-url
   "Build the authorization url."

--- a/src/loudmoauth/provider.clj
+++ b/src/loudmoauth/provider.clj
@@ -43,7 +43,7 @@
 (defn auth-url
   "Build the authorization url."
   [provider-data]
-  (str (:base-url provider-data) (:auth-endpoint provider-data) "/?" (query-param-string provider-data)))
+  (str (:base-url provider-data) (:auth-endpoint provider-data) "?" (query-param-string provider-data)))
 
 (defn token-url
   "Build the url for retreieving tokens."

--- a/test/loudmoauth/test_fixtures.clj
+++ b/test/loudmoauth/test_fixtures.clj
@@ -4,9 +4,9 @@
 (def test-state-value "34fFs29kd09")
 
 (def test-state-value-keyword (keyword test-state-value)) 
-(def test-query-param-string "client_id=5fe01282e44241328a84e7c5cc169165&response_type=code&redirect_uri=https%3A%2F%2Fwww.example.com%2Fcallback&scope=user-read-private+user-read-email&state=34fFs29kd09") 
+(def test-query-param-string "client_id=5fe01282e44241328a84e7c5cc169165&response_type=code&redirect_uri=https%3A%2F%2Fwww.example.com%2Fcallback&scope=user-read-private%20user-read-email&state=34fFs29kd09") 
 
-(def test-custom-param-query-param-string  "client_id=5fe01282e44241328a84e7c5cc169165&response_type=code&redirect_uri=https%3A%2F%2Fwww.example.com%2Fcallback&scope=user-read-private+user-read-email&state=34fFs29kd09&show_dialog=true") 
+(def test-custom-param-query-param-string  "client_id=5fe01282e44241328a84e7c5cc169165&response_type=code&redirect_uri=https%3A%2F%2Fwww.example.com%2Fcallback&scope=user-read-private%20user-read-email&state=34fFs29kd09&show_dialog=true") 
 
 (def test-encoded-string "SSdtIGdsYWQgSSB3b3JlIHRoZXNlIHBhbnRzLg==")
 
@@ -37,7 +37,7 @@
 
 (def test-state-code-params (:params test-code-http-response))
 
-(def auth-url (str "https://www.example.com/authorize/?" test-custom-param-query-param-string))
+(def auth-url (str "https://www.example.com/authorize?" test-custom-param-query-param-string))
 
 (def token-url "https://www.example.com/api/token") 
 
@@ -64,7 +64,7 @@
 (def provider-data
   {:access_token (ref nil)
    :auth-endpoint "/authorize"
-   :auth-url (str "https://www.example.com/authorize/?" test-custom-param-query-param-string)
+   :auth-url (str "https://www.example.com/authorize?" test-custom-param-query-param-string)
    :base-url "https://www.example.com"
    :client-id "5fe01282e44241328a84e7c5cc169165"
    :client-secret "123456789secret"
@@ -92,7 +92,7 @@
 (def final-provider-data
   {:access_token (ref "a12dkdirnc")
    :auth-endpoint "/authorize"
-   :auth-url (str "https://www.example.com/authorize/?" test-custom-param-query-param-string)
+   :auth-url (str "https://www.example.com/authorize?" test-custom-param-query-param-string)
    :base-url "https://www.example.com"
    :client-id "5fe01282e44241328a84e7c5cc169165"
    :client-secret "123456789secret"


### PR DESCRIPTION
Typically, query params are prefixed by "?" only, not "/?" (which would put the params on their own path).